### PR TITLE
chore: Update repository name for Eclipse Apoapsis GitHub actions

### DIFF
--- a/renovate-global.json
+++ b/renovate-global.json
@@ -3,9 +3,9 @@
   "branchPrefix": "renovate-action/",
   "gitAuthor": "eclipse-apoapsis-bot <159786767+eclipse-apoapsis-bot@users.noreply.github.com>",
   "repositories": [
+    "eclipse-apoapsis/actions",
     "eclipse-apoapsis/guidance",
     "eclipse-apoapsis/ort-server",
-    "eclipse-apoapsis/renovate",
-    "eclipse-apoapsis/setup-osc"
+    "eclipse-apoapsis/renovate"
   ]
 }


### PR DESCRIPTION
The repository was renamed in [1].

[1]: https://github.com/eclipse-apoapsis/.eclipsefdn/commit/28c981f30c3ebf539337cc733636a5484baeb2b1